### PR TITLE
feat(api): make get id methods more flexible

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ export default class Highlighter extends EventEmitter {
             return;
         }
 
-        const id = getHighlightId($target);
+        const id = getHighlightId($target, this.options.$root);
         // prevent trigger in the same highlight range
         if (this._hoverId === id) {
             return;
@@ -133,7 +133,7 @@ export default class Highlighter extends EventEmitter {
     private _handleHighlightClick = (e): void => {
         const $target = e.target as HTMLElement;
         if (isHighlightWrapNode($target)) {
-            const id = getHighlightId($target);
+            const id = getHighlightId($target, this.options.$root);
             this.emit(EventType.CLICK, {id}, this, e);
         }
     }
@@ -144,8 +144,8 @@ export default class Highlighter extends EventEmitter {
     addClass = (className: string, id?: string) => this.getDoms(id).forEach($n => addClass($n, className));
     removeClass = (className: string, id?: string) => this.getDoms(id).forEach($n => removeClass($n, className));
 
-    getIdByDom = ($node: HTMLElement): string => getHighlightId($node);
-    getExtraIdByDom = ($node: HTMLElement): string[] => getExtraHighlightId($node);
+    getIdByDom = ($node: HTMLElement): string => getHighlightId($node, this.options.$root);
+    getExtraIdByDom = ($node: HTMLElement): string[] => getExtraHighlightId($node, this.options.$root);
     getDoms = (id?: string): Array<HTMLElement> => id
         ? getHighlightById(this.options.$root, id, this.options.wrapTag)
         : getHighlightsByRoot(this.options.$root, this.options.wrapTag);

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -1,7 +1,3 @@
-/**
- * @file dom 操作相关的通用工具类
- */
-
 import {RootElement} from '../types';
 import {
     ID_DIVISION,
@@ -18,24 +14,53 @@ export const isHighlightWrapNode = ($node: HTMLElement): boolean => (
 );
 
 /**
- * get highlight id by wrapping node
+ * ===================================================================================
+ * below methods (getHighlightId/getExtraHighlightId)
+ * will check whether the node is inside a wrapper iteratively util reach the root node
+ * if the node is not inside the root, the id must be empty
+ * ====================================================================================
  */
-export const getHighlightId = ($node: HTMLElement): string => {
-    if (isHighlightWrapNode($node)) {
-        return $node.dataset[CAMEL_DATASET_IDENTIFIER];
+
+const findAncestorWrapperInRoot = ($node: HTMLElement, $root: RootElement): HTMLElement => {
+    let isInsideRoot = false;
+    let $wrapper: HTMLElement = null;
+    while ($node) {
+        if (isHighlightWrapNode($node)) {
+            $wrapper = $node;
+        }
+        if ($node === $root) {
+            isInsideRoot = true;
+            break;
+        }
+        $node = $node.parentNode as HTMLElement;
     }
-    return '';
+    return isInsideRoot ? $wrapper : null;
+}
+
+/**
+ * get highlight id by a node
+ */
+export const getHighlightId = ($node: HTMLElement, $root: RootElement): string => {
+    $node = findAncestorWrapperInRoot($node, $root);
+    if (!$node) {
+        return '';
+   }
+
+    return $node.dataset[CAMEL_DATASET_IDENTIFIER];
 };
 
 /**
- * get extra highlight id by wrapping node
+ * get extra highlight id by a node
  */
-export const getExtraHighlightId = ($node: HTMLElement): string[] => {
-    if (isHighlightWrapNode($node)) {
-        const extraId = $node.dataset[CAMEL_DATASET_IDENTIFIER_EXTRA];
-        return extraId.split(ID_DIVISION).filter(i => i);
+export const getExtraHighlightId = ($node: HTMLElement, $root: RootElement): string[] => {
+    $node = findAncestorWrapperInRoot($node, $root);
+    if (!$node) {
+         return [];
     }
-    return [];
+
+    return $node.dataset[CAMEL_DATASET_IDENTIFIER_EXTRA]
+        .split(ID_DIVISION)
+        .filter(i => i);
 };
 
 /**

--- a/test/api.spec.ts
+++ b/test/api.spec.ts
@@ -401,13 +401,33 @@ describe('Highlighter API', function () {
             sources.forEach(s => highlighter.fromStore(s.startMeta, s.endMeta, s.text, s.id));
         });
 
-        it('should return the correct id', () => {
+        it('should return the correct id when it\'s a wrapper', () => {
             const id = sources[0].id;
             const dom = highlighter.getDoms(id)[0];
             expect(highlighter.getIdByDom(dom)).to.be.equal(id);
         });
 
-        it('should be empty(\'\') when the dom is not a wrapper', () => {
+        it('should return the correct id when it\'s inside a wrapper', () => {
+            const id = sources[0].id;
+            const dom = highlighter.getDoms(id)[0];
+            expect(highlighter.getIdByDom(dom.childNodes[0] as HTMLElement)).to.be.equal(id);
+        });
+
+        it('should return \'\' when it\'s outside a wrapper', () => {
+            const id = sources[0].id;
+            const dom = highlighter.getDoms(id)[0];
+            expect(highlighter.getIdByDom(dom.parentElement)).to.be.empty;
+        });
+
+        it('should return \'\' when a valid wrapper is outside the root', () => {
+            const footerHighlighter = new Highlighter({
+                $root: document.querySelector('footer')
+            });
+            const dom = highlighter.getDoms(sources[0].id)[0];
+            expect(footerHighlighter.getIdByDom(dom)).to.be.empty;
+        });
+
+        it('should return \'\' when the dom is not be wrapped', () => {
             expect(highlighter.getIdByDom(document.querySelector('img'))).to.be.empty;
         });
     });
@@ -418,19 +438,41 @@ describe('Highlighter API', function () {
             sources.forEach(s => highlighter.fromStore(s.startMeta, s.endMeta, s.text, s.id));
         });
 
-        it('should return the correct id', () => {
+        it('should return the correct ids when it\'s a wrapper', () => {
             const id = sources[0].id;
             const dom = highlighter.getDoms(id)[2];
             const ids = highlighter.getExtraIdByDom(dom);
             expect(ids.sort()).to.deep.equal([sources[0].id, sources[1].id].sort());
         });
 
-        it('should return empty array when there is no extra id', () => {
+        it('should return the correct ids when it\'s inside a wrapper', () => {
+            const id = sources[0].id;
+            const dom = highlighter.getDoms(id)[2].childNodes[0];
+            const ids = highlighter.getExtraIdByDom(dom as HTMLElement);
+            expect(ids.sort()).to.deep.equal([sources[0].id, sources[1].id].sort());
+        });
+
+        it('should return [] when it\'s outside a wrapper', () => {
+            const id = sources[0].id;
+            const dom = highlighter.getDoms(id)[2].parentElement;
+            const ids = highlighter.getExtraIdByDom(dom);
+            expect(ids).to.deep.equal([]);
+        });
+
+        it('should return [] when a valid wrapper is outside the root', () => {
+            const footerHighlighter = new Highlighter({
+                $root: document.querySelector('footer')
+            });
+            const dom = highlighter.getDoms(sources[0].id)[0];
+            expect(footerHighlighter.getExtraIdByDom(dom)).to.deep.equal([]);
+        });
+
+        it('should return [] when there is no extra id', () => {
             const dom = highlighter.getDoms(sources[0].id)[0];
             expect(highlighter.getExtraIdByDom(dom)).to.deep.equal([]);
         });
 
-        it('should return empty array when the dom is not a wrapper', () => {
+        it('should return [] when the dom is not be wrapped', () => {
             expect(highlighter.getExtraIdByDom(document.querySelector('img'))).to.deep.equal([]);
         });
     });

--- a/test/fixtures/index.html
+++ b/test/fixtures/index.html
@@ -7,3 +7,4 @@
     <p>This is a useful feature for readers.<span class="highlight-mengshou-wrap" data-highlight-id="8a4cf231-6601-49f2-9137-e7677d592312" data-highlight-split-type="both" data-highlight-id-extra="">If you're a developer, you may want your website support it and attract more visits.</span>If you're a user (like me), you may want a browser-plugin to do this.</p>
     <p>For this reason, the repo (web-highlighter) aims to help you implement highlighting-note on any website quickly (e.g. blogs, document viewers, online books and so on). It contains the core abilities for note highlighting and persistence. And you can implement your own product by some easy-to-use APIs. It has been used for our sites in production.</p>
 </main>
+<footer>This is a footer</footer>

--- a/test/util.spec.ts
+++ b/test/util.spec.ts
@@ -6,6 +6,7 @@ import Cache from '../src/data/cache';
 import Hook from '../src/util/hook';
 import EventEmitter from '../src/util/event.emitter';
 import { initDefaultStylesheet } from '../src/painter/style';
+import { addEventListener } from '../src/util/dom';
 import sinon from 'sinon';
 
 describe('Else Utils', function () {
@@ -63,6 +64,7 @@ describe('Else Utils', function () {
             expect(document.querySelectorAll('style')).lengthOf(1);
             initDefaultStylesheet();
             expect(document.querySelectorAll('style')).lengthOf(1);
+            cleanup();
         });
     });
 
@@ -202,6 +204,41 @@ describe('Else Utils', function () {
             event.emit('test');
 
             expect(spy.calledOnce).to.be.true;
+        });
+    });
+
+    describe('DOM addEventListener', () => {
+        it('should add listener correctly', () => {
+            const cleanup = jsdomGlobal('<button>test</button>');
+            
+            const spy: sinon.SinonSpy<any[], any[]> = sinon.spy();
+            const dom = document.querySelector('button');
+            addEventListener(dom, 'click', spy);
+            dom.dispatchEvent(new MouseEvent('click', {
+                view: window,
+                bubbles: true,
+                cancelable: true
+            }));
+
+            expect(spy.calledOnce).to.be.true;
+            cleanup();
+        });
+
+        it('should remove listener correctly', () => {
+            const cleanup = jsdomGlobal('<button>test</button>');
+            
+            const spy: sinon.SinonSpy<any[], any[]> = sinon.spy();
+            const dom = document.querySelector('button');
+            const remove = addEventListener(dom, 'click', spy);
+            remove();
+            dom.dispatchEvent(new MouseEvent('click', {
+                view: window,
+                bubbles: true,
+                cancelable: true
+            }));
+
+            expect(spy.callCount).to.be.equal(0);
+            cleanup();
         });
     });
 });


### PR DESCRIPTION
- It will get correct id(s) inside a wrapper. No need to be a wrapper element.
- It is limited in the root scope.