### PR TITLE
Set types property to point to the declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.1",
   "description": "✨A no-runtime dependency lib for text highlighting & persistence on any website ✨🖍️",
   "main": "dist/web-highlighter.min.js",
+  "types": "dist/index.d.ts",
   "browser": "dist/web-highlighter.min.js",
   "scripts": {
     "lint": "eslint \"src/**/*.ts\" --fix",


### PR DESCRIPTION
The types are still not resolved by Typescript, looks like the entry
has to be set specifically

related issue #50