### PR TITLE
fix(classname): keep the only latest classname when wrapping a partial node or an overlap node

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -7,6 +7,11 @@ const highlighter = new Highlighter({
     wrapTag: 'i',
     exceptSelectors: ['.my-remove-tip', 'pre', 'code']
 });
+highlighter.setOption({
+    style: {
+        className: 'yellow-highlight',
+    },
+});
 const store = new LocalStore();
 const log = console.log.bind(console, '[highlighter]');
 
@@ -38,6 +43,14 @@ const switchAuto = auto => {
         $btn.removeAttribute('disabled');
     }
 };
+
+const switchColor = color => highlighter.setOption({
+    style: {
+        className: color === 'yellow'
+            ? 'yellow-highlight'
+            : 'blue-highlight',
+    },
+});
 
 function getPosition($node) {
     let offset = {
@@ -83,42 +96,42 @@ highlighter
     });
 
 /**
- * avoid re-highlighting the existing selection
+ * FIXME: avoid re-highlighting the existing selection
  */
-function getIds(selected) {
-    if (!selected || !selected.$node || !selected.$node.parentNode) {
-        return [];
-    }
-    return [
-        highlighter.getIdByDom(selected.$node.parentNode),
-        ...highlighter.getExtraIdByDom(selected.$node.parentNode)
-    ].filter(i => i)
-}
-function getIntersection(arrA, arrB) {
-    const record = {};
-    const intersection = [];
-    arrA.forEach(i => record[i] = true);
-    arrB.forEach(i => record[i] && intersection.push(i) && (record[i] = false));
-    return intersection;
-}
-highlighter.hooks.Render.SelectedNodes.tap((id, selectedNodes) => {
-    selectedNodes = selectedNodes.filter(n => n.$node.textContent);
-    if (selectedNodes.length === 0) {
-        return [];
-    }
+// function getIds(selected) {
+//     if (!selected || !selected.$node || !selected.$node.parentNode) {
+//         return [];
+//     }
+//     return [
+//         highlighter.getIdByDom(selected.$node.parentNode),
+//         ...highlighter.getExtraIdByDom(selected.$node.parentNode)
+//     ].filter(i => i)
+// }
+// function getIntersection(arrA, arrB) {
+//     const record = {};
+//     const intersection = [];
+//     arrA.forEach(i => record[i] = true);
+//     arrB.forEach(i => record[i] && intersection.push(i) && (record[i] = false));
+//     return intersection;
+// }
+// highlighter.hooks.Render.SelectedNodes.tap((id, selectedNodes) => {
+//     selectedNodes = selectedNodes.filter(n => n.$node.textContent);
+//     if (selectedNodes.length === 0) {
+//         return [];
+//     }
 
-    const candidates = selectedNodes.slice(1).reduce(
-        (left, selected) => getIntersection(left, getIds(selected)),
-        getIds(selectedNodes[0])
-    );
-    for (let i = 0; i < candidates.length; i++) {
-        if (highlighter.getDoms(candidates[i]).length === selectedNodes.length) {
-            return [];
-        }
-    }
+//     const candidates = selectedNodes.slice(1).reduce(
+//         (left, selected) => getIntersection(left, getIds(selected)),
+//         getIds(selectedNodes[0])
+//     );
+//     for (let i = 0; i < candidates.length; i++) {
+//         if (highlighter.getDoms(candidates[i]).length === selectedNodes.length) {
+//             return [];
+//         }
+//     }
 
-    return selectedNodes;
-});
+//     return selectedNodes;
+// });
 
 highlighter.hooks.Serialize.Restore.tap(
     source =>  log('Serialize.Restore hook -', source)
@@ -146,6 +159,7 @@ document.querySelectorAll('[name="auto"]').forEach($n => {
 });
 switchAuto(autoStatus);
 
+let colorStatus = 'yellow';
 document.addEventListener('click', e => {
     const $ele = e.target;
 
@@ -163,6 +177,14 @@ document.addEventListener('click', e => {
         if (autoStatus !== val) {
             switchAuto(val);
             autoStatus = val;
+        }
+    }
+    // toggle highlighting color
+    else if ($ele.getAttribute('name') === 'color') {
+        const val = $ele.value;
+        if (colorStatus !== val) {
+            switchColor(val);
+            colorStatus = val;
         }
     }
     // highlight range manually

--- a/example/tpl.html
+++ b/example/tpl.html
@@ -16,6 +16,14 @@
             img {
                 max-width: 100%;
             }
+
+            .yellow-highlight {
+                background-color: #FF9;
+            }
+
+            .blue-highlight {
+                background-color: #9FF;
+            }
         </style>
         <title>Web Highlighter: a mini tool for highlighting website text</title>
     </head>
@@ -36,6 +44,11 @@
                 <label class="op-name">auto-highlight：</label>
                 <label><input name="auto" type="radio" value="on" checked />enabled</label>
                 <label><input name="auto" type="radio" value="off" />disabled</label>
+            </div>
+            <div>
+                <label class="op-color">color：</label>
+                <label><input name="color" type="radio" value="yellow" checked />yellow</label>
+                <label><input name="color" type="radio" value="blue" />blue</label>
             </div>
             <button class="op-btn disabled" id="js-highlight" disabled >highlight manually</button>
             <a href="https://github.com/alienzhou/web-highlighter" target="_blank">

--- a/src/painter/dom.ts
+++ b/src/painter/dom.ts
@@ -1,7 +1,7 @@
 import type HighlightRange from '../model/range';
 import type { SelectedNode, DomNode } from '../types';
 import { SplitType, SelectedNodeType } from '../types';
-import { hasClass, addClass as addElementClass, isHighlightWrapNode } from '../util/dom';
+import { hasClass, addClass as addElementClass, isHighlightWrapNode, removeAllClass } from '../util/dom';
 import {
     ID_DIVISION,
     getDefaultOptions,
@@ -231,10 +231,6 @@ const wrapPartialNode = (
 
     const classNameList: string[] = [];
 
-    if (isHighlightWrapNode($parent)) {
-        $parent.classList.forEach(c => classNameList.push(c));
-    }
-
     if (Array.isArray(className)) {
         classNameList.push(...className);
     } else {
@@ -275,6 +271,7 @@ const wrapOverlapNode = (selected: SelectedNode, range: HighlightRange, classNam
     const $parent = selected.$node.parentNode as HTMLElement;
     const $wrap: HTMLElement = $parent;
 
+    removeAllClass($wrap);
     addClass($wrap, className);
 
     const dataset = $parent.dataset;

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -139,4 +139,8 @@ export const removeClass = ($el: HTMLElement, className: string): void => {
     $el.classList.remove(className);
 };
 
+export const removeAllClass = ($el: HTMLElement): void => {
+    $el.className = '';
+};
+
 export const hasClass = ($el: HTMLElement, className: string): boolean => $el.classList.contains(className);

--- a/test/api.spec.ts
+++ b/test/api.spec.ts
@@ -490,6 +490,42 @@ describe('Highlighter API', function () {
         });
     });
 
+    describe('complicated use cases', () => {
+        it('should set the only new className on an already existed wrapper after highlighting', () => {
+            const range = document.createRange();
+            const $p = document.querySelectorAll('p')[3];
+            range.setStart($p.querySelector('span').childNodes[0], 64);
+            range.setEnd($p.querySelector('span').nextSibling, 9);
+            highlighter.fromRange(range);
+
+            const $span = $p.querySelectorAll(wrapSelector)[1];
+            const range2 = document.createRange();
+            range2.setStart($span.childNodes[0], 0);
+            range2.setEnd($span.childNodes[0], 20);
+            highlighter.setOption({ style: { className: 'highlight-test' } });
+            highlighter.fromRange(range2);
+
+            const $wraps = $p.querySelectorAll(wrapSelector);
+            expect($wraps[1].className).to.be.equal('highlight-test');
+        });
+
+        it('should set the only new className on a split wrapper after highlighting', () => {
+            const range = document.createRange();
+            const $p = document.querySelectorAll('p')[3];
+            const $highlight = $p.querySelector('span');
+            range.setStart($highlight.childNodes[0], 12);
+            range.setEnd($highlight.childNodes[0], 21);
+            
+            // change className and highlight it 
+            highlighter.setOption({ style: { className: 'highlight-test' } });
+            highlighter.fromRange(range);
+            
+            const $wraps = $p.querySelectorAll(wrapSelector);
+            
+            expect($wraps[1].className).to.be.equal('highlight-test');
+        });
+    });
+
     afterEach(() => {
         cleanup();
     });


### PR DESCRIPTION
After changing the `className` by `.setOption()`, highlighting a node still retains its existing classnames.

https://github.com/alienzhou/web-highlighter/blob/576508afd218d10218160d89b7b0ab048540d6dc/src/painter/dom.ts#L234-L236

https://github.com/alienzhou/web-highlighter/blob/576508afd218d10218160d89b7b0ab048540d6dc/src/painter/dom.ts#L278

As a result it may hit a wrong style rule.

With styles below

```css
.yellow {
  background-color: #FF9;
}
.blue {
  background-color: #9FF;
}
```

The wrappers with `class="yellow blue"` and `class="blue yellow"` look the same. But they should be different.