### PR TITLE
From store docs fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ import Highlighter from 'web-highlighter';
 const highlighter = new Highlighter();
 
 // 2. retrieve data from backend, then highlight it on the page
-getRemoteData().then(s => highlighter.fromStore(s.startMeta, s.endMeta, s.id, s.text));
+getRemoteData().then(s => highlighter.fromStore(s.startMeta, s.endMeta, s.text, s.id));
 
 // 3. listen for highlight creating, then save to backend
 highlighter.on(Highlighter.event.CREATE, ({sources}) => save(sources));

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -67,7 +67,7 @@ import Highlighter from 'web-highlighter';
 const highlighter = new Highlighter();
 
 // 2. 从后端获取高亮信息，还原至网页
-getRemoteData().then(s => highlighter.fromStore(s.startMeta, s.endMeta, s.id, s.text));
+getRemoteData().then(s => highlighter.fromStore(s.startMeta, s.endMeta, s.text, s.id));
 
 // 3. 监听高亮笔记创建事件，并将信息存至后端
 highlighter.on(Highlighter.event.CREATE, ({sources}) => save(sources));


### PR DESCRIPTION
I was looking through the docs and noticed an inconsistency in the order of parameters to the `fromStore` call. Based on the function definition, the order of the parameters is `startMeta` `endMeta`, `text`, `id`, and `extra`. This is called correctly in the [complex example section](https://github.com/alienzhou/web-highlighter#example) but not in the [usage section](https://github.com/alienzhou/web-highlighter#usage).

This PR updates the parameters to the correct order in the usage section.