### PR TITLE
fix: stop at excluded range end

### DIFF
--- a/src/painter/dom.ts
+++ b/src/painter/dom.ts
@@ -105,6 +105,10 @@ export const getSelectedNodes = (
     while ((curNode = nodeStack.pop())) {
         // do not traverse the excepted node
         if (curNode.nodeType === 1 && isExcepted(curNode as HTMLElement)) {
+            if (curNode.contains($endNode)) {
+                break;
+            }
+
             continue;
         }
 

--- a/test/dist.spec.ts
+++ b/test/dist.spec.ts
@@ -6,6 +6,41 @@ import { JSDOM } from 'jsdom';
 describe('Distribution bundle', function () {
     this.timeout(50000);
 
+    it('stops before an excluded end node', () => {
+        const bundle = readFileSync(resolve(__dirname, '..', 'dist', 'web-highlighter.min.js'), 'utf-8');
+        const dom = new JSDOM(
+            '<main><p>before <span class="excluded">excluded</span> after</p><p>unrelated</p></main>',
+            {
+                runScripts: 'dangerously',
+            },
+        );
+        const { window } = dom;
+
+        window.eval(bundle);
+
+        const Highlighter = (window as typeof window & { Highlighter: new (options?: any) => any }).Highlighter;
+        const paragraph = window.document.querySelector('p');
+        const excluded = paragraph?.querySelector('.excluded');
+
+        if (!Highlighter || !paragraph || !paragraph.firstChild || !excluded?.firstChild) {
+            throw new Error('Expected test document structure');
+        }
+
+        const highlighter = new Highlighter({ exceptSelectors: ['.excluded'] });
+        const range = window.document.createRange();
+
+        range.setStart(paragraph.firstChild, 0);
+        range.setEnd(excluded.firstChild, 3);
+        highlighter.fromRange(range);
+
+        expect(highlighter.getDoms().map(($node: Element) => $node.textContent)).to.deep.equal(['before ']);
+        expect(window.document.querySelectorAll('[data-highlight-id]')).to.have.lengthOf(1);
+        expect(paragraph.textContent).to.equal('before excluded after');
+        expect(window.document.querySelectorAll('p')[1].textContent).to.equal('unrelated');
+
+        window.close();
+    });
+
     it('exposes the UMD global and supports the highlight lifecycle', () => {
         const bundle = readFileSync(resolve(__dirname, '..', 'dist', 'web-highlighter.min.js'), 'utf-8');
         const dom = new JSDOM('<main><p>Highlight this text.</p></main>', {
@@ -15,7 +50,7 @@ describe('Distribution bundle', function () {
 
         window.eval(bundle);
 
-        const Highlighter = (window as typeof window & { Highlighter: new () => any }).Highlighter;
+        const Highlighter = (window as typeof window & { Highlighter: new (options?: any) => any }).Highlighter;
 
         expect(Highlighter).to.be.a('function');
 

--- a/test/option.spec.ts
+++ b/test/option.spec.ts
@@ -8,10 +8,11 @@ import { getDefaultOptions } from '../src/util/const';
 describe('Highlighter Options', function () {
     this.timeout(50000);
 
-    let cleanup: Function;
+    let cleanup: () => void;
 
     beforeEach(() => {
         const html = readFileSync(resolve(__dirname, 'fixtures', 'index.html'), 'utf-8');
+
         cleanup = jsdomGlobal();
         document.body.innerHTML = html;
     });
@@ -20,11 +21,13 @@ describe('Highlighter Options', function () {
         it('should highlight text inside $root', () => {
             const $root = document.querySelectorAll('p')[0];
             const highlighter = new Highlighter({ $root });
+
             highlighter.removeAll();
 
             expect(highlighter.getDoms()).lengthOf(0);
 
             const range = document.createRange();
+
             range.setStart($root.childNodes[0], 0);
             range.setEnd($root.childNodes[0], 17);
             highlighter.fromRange(range);
@@ -35,11 +38,13 @@ describe('Highlighter Options', function () {
         it('should not highlight text outside $root', () => {
             const $root = document.querySelectorAll('p')[0];
             const highlighter = new Highlighter({ $root });
+
             highlighter.removeAll();
             expect(highlighter.getDoms()).lengthOf(0);
 
             const range = document.createRange();
             const $p = document.querySelectorAll('p')[1];
+
             range.setStart($p.childNodes[0], 0);
             range.setEnd($p.childNodes[0], 17);
             highlighter.fromRange(range);
@@ -49,15 +54,16 @@ describe('Highlighter Options', function () {
     });
 
     describe('#exceptSelectors', () => {
-
         it('should skip nodes because of the tag selector filters', () => {
             const highlighter = new Highlighter({
-                exceptSelectors: ['p']
+                exceptSelectors: ['p'],
             });
+
             highlighter.removeAll();
 
             const $p = document.querySelectorAll('p')[0];
             const range = document.createRange();
+
             range.setStart($p.childNodes[0], 0);
             range.setEnd($p.childNodes[0], 17);
             highlighter.fromRange(range);
@@ -67,12 +73,14 @@ describe('Highlighter Options', function () {
 
         it('should skip nodes because of the className selector filters', () => {
             const highlighter = new Highlighter({
-                exceptSelectors: ['.first-p']
+                exceptSelectors: ['.first-p'],
             });
+
             highlighter.removeAll();
 
             const $p = document.querySelectorAll('p')[0];
             const range = document.createRange();
+
             range.setStart($p.childNodes[0], 0);
             range.setEnd($p.childNodes[0], 17);
             highlighter.fromRange(range);
@@ -82,12 +90,14 @@ describe('Highlighter Options', function () {
 
         it('should skip nodes because of the id selector filters', () => {
             const highlighter = new Highlighter({
-                exceptSelectors: ['#js-first-p']
+                exceptSelectors: ['#js-first-p'],
             });
+
             highlighter.removeAll();
 
             const $p = document.querySelectorAll('p')[0];
             const range = document.createRange();
+
             range.setStart($p.childNodes[0], 0);
             range.setEnd($p.childNodes[0], 17);
             highlighter.fromRange(range);
@@ -97,66 +107,137 @@ describe('Highlighter Options', function () {
 
         it('should not skip when no filter matches', () => {
             const highlighter = new Highlighter({
-                exceptSelectors: ['.no-match']
+                exceptSelectors: ['.no-match'],
             });
+
             highlighter.removeAll();
 
             const $p = document.querySelectorAll('p')[0];
             const range = document.createRange();
+
             range.setStart($p.childNodes[0], 0);
             range.setEnd($p.childNodes[0], 17);
             highlighter.fromRange(range);
 
             expect(highlighter.getDoms()).lengthOf.gt(0);
         });
+
+        it('should stop at an end node inside an excluded element', () => {
+            document.body.innerHTML =
+                '<main><p>before <span class="excluded">excluded</span> after</p><p>unrelated</p></main>';
+
+            const highlighter = new Highlighter({
+                exceptSelectors: ['.excluded'],
+            });
+            const $paragraphs = document.querySelectorAll('p');
+            const $firstText = $paragraphs[0].firstChild;
+            const $excludedText = $paragraphs[0].querySelector('.excluded').firstChild;
+            const range = document.createRange();
+
+            range.setStart($firstText, 0);
+            range.setEnd($excludedText, 3);
+            highlighter.fromRange(range);
+
+            expect(highlighter.getDoms().map($node => $node.textContent)).to.deep.equal(['before ']);
+            expect($paragraphs[0].textContent).to.equal('before excluded after');
+            expect($paragraphs[1].textContent).to.equal('unrelated');
+        });
+
+        it('should highlight text after an excluded start node', () => {
+            document.body.innerHTML = '<main><p>before <span class="excluded">excluded</span> after</p></main>';
+
+            const highlighter = new Highlighter({
+                exceptSelectors: ['.excluded'],
+            });
+            const $paragraph = document.querySelector('p');
+            const $excludedText = $paragraph.querySelector('.excluded').firstChild;
+            const $lastText = $paragraph.lastChild;
+            const range = document.createRange();
+
+            range.setStart($excludedText, 3);
+            range.setEnd($lastText, 3);
+            highlighter.fromRange(range);
+
+            expect(highlighter.getDoms().map($node => $node.textContent)).to.deep.equal([' af']);
+            expect($paragraph.textContent).to.equal('before excluded after');
+        });
+
+        it('should stop at the first excluded end ancestor when multiple nodes are excluded', () => {
+            document.body.innerHTML = [
+                '<main><p>before <span class="excluded">first</span> between ',
+                '<span class="excluded">second</span> after</p><p>unrelated</p></main>',
+            ].join('');
+
+            const highlighter = new Highlighter({
+                exceptSelectors: ['.excluded'],
+            });
+            const $paragraphs = document.querySelectorAll('p');
+            const $firstText = $paragraphs[0].firstChild;
+            const $excludedText = $paragraphs[0].querySelectorAll('.excluded')[1].firstChild;
+            const range = document.createRange();
+
+            range.setStart($firstText, 0);
+            range.setEnd($excludedText, 3);
+            highlighter.fromRange(range);
+
+            expect(highlighter.getDoms().map($node => $node.textContent)).to.deep.equal(['before ', ' between ']);
+            expect($paragraphs[0].textContent).to.equal('before first between second after');
+            expect($paragraphs[1].textContent).to.equal('unrelated');
+        });
     });
 
     describe('#wrapTag', () => {
-        it('should use default tag for wrapping node when there\'s no config', () => {
+        it("should use default tag for wrapping node when there's no config", () => {
             const wrapTag = getDefaultOptions().wrapTag;
             const highlighter = new Highlighter();
+
             highlighter.removeAll();
 
             const $p = document.querySelectorAll('p')[0];
             const range = document.createRange();
+
             range.setStart($p.childNodes[0], 0);
             range.setEnd($p.childNodes[0], 17);
             highlighter.fromRange(range);
 
             expect(highlighter.getDoms()).lengthOf.gt(0);
-            const useCorrectTag = highlighter
-                .getDoms()
-                .every(n => n.tagName.toUpperCase() === wrapTag.toUpperCase());
+
+            const useCorrectTag = highlighter.getDoms().every(n => n.tagName.toUpperCase() === wrapTag.toUpperCase());
+
             expect(useCorrectTag).to.be.true;
         });
 
         it('should use customized tag for wrapping nodes', () => {
             const wrapTag = getDefaultOptions().wrapTag === 'b' ? 'i' : 'b';
             const highlighter = new Highlighter({ wrapTag });
+
             highlighter.removeAll();
 
             const $p = document.querySelectorAll('p')[0];
             const range = document.createRange();
+
             range.setStart($p.childNodes[0], 0);
             range.setEnd($p.childNodes[0], 17);
             highlighter.fromRange(range);
 
             expect(highlighter.getDoms()).lengthOf.gt(0);
-            const useCorrectTag = highlighter
-                .getDoms()
-                .every(n => n.tagName.toUpperCase() === wrapTag.toUpperCase());
+
+            const useCorrectTag = highlighter.getDoms().every(n => n.tagName.toUpperCase() === wrapTag.toUpperCase());
+
             expect(useCorrectTag).to.be.true;
         });
     });
 
     describe('#style.className', () => {
-        it('should use default className for wrapping nodes when there\'s no config', () => {
+        it("should use default className for wrapping nodes when there's no config", () => {
             const defaultClassName = getDefaultOptions().style.className;
             const highlighter = new Highlighter();
+
             highlighter.removeAll();
 
             const $p = document.querySelectorAll('p')[0];
             const range = document.createRange();
+
             range.setStart($p.childNodes[0], 0);
             range.setEnd($p.childNodes[0], 17);
             highlighter.fromRange(range);
@@ -169,12 +250,14 @@ describe('Highlighter Options', function () {
             const className = 'test-class-config';
             const defaultClassName = getDefaultOptions().style.className;
             const highlighter = new Highlighter({
-                style: { className }
+                style: { className },
             });
+
             highlighter.removeAll();
 
             const $p = document.querySelectorAll('p')[0];
             const range = document.createRange();
+
             range.setStart($p.childNodes[0], 0);
             range.setEnd($p.childNodes[0], 17);
             highlighter.fromRange(range);
@@ -188,20 +271,24 @@ describe('Highlighter Options', function () {
             const className = ['test-class-config-1', 'test-class-config-2'];
             const defaultClassName = getDefaultOptions().style.className;
             const highlighter = new Highlighter({
-                style: { className }
+                style: { className },
             });
+
             highlighter.removeAll();
 
             const $p = document.querySelectorAll('p')[0];
             const range = document.createRange();
+
             range.setStart($p.childNodes[0], 0);
             range.setEnd($p.childNodes[0], 17);
             highlighter.fromRange(range);
 
             expect(highlighter.getDoms()).lengthOf.gt(0);
-            expect(highlighter.getDoms().every(n => 
-                n.classList.contains(className[0]) && n.classList.contains(className[1])
-            )).to.be.true;
+            expect(
+                highlighter
+                    .getDoms()
+                    .every(n => n.classList.contains(className[0]) && n.classList.contains(className[1])),
+            ).to.be.true;
             expect(highlighter.getDoms().some(n => n.classList.contains(defaultClassName))).to.be.false;
         });
     });


### PR DESCRIPTION
## Summary
- stop selected-node traversal when an excluded element contains the Range end node
- prevent highlights from extending past `exceptSelectors` boundaries
- cover the boundary in unit tests and the built UMD bundle

Fixes #128
Fixes #114

## Validation
- `npm run lint`
- `npm run test:types`
- `npm test`
- `npm run coverage`
- `npm audit` (0 vulnerabilities)

## Browser coverage
- The built UMD bundle is exercised in JSDOM.
- Real-browser automation is unavailable in the current environment, so a Playwright smoke test remains a follow-up.