### PR TITLE
docs: clarify runtime boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ Another real product built with web-highlighter (for the highlighting area on th
 
 It will read the selected range by [`Selection API`](https://caniuse.com/#search=selection%20api). Then the information of the range will be converted to a serializable data structure so that it can be store in backend. When users visit your page next time, these data will be returned and deserialized in your page. The data structure is tech stack independent. So you can use on any 'static' pages made with React / Vue / Angular / jQuery and others.
 
+### Persistence constraints
+
+Persisted highlights record DOM paths and text offsets relative to `$root`; they are not screen coordinates. Restore highlights only after the content is fully rendered, and keep the same `$root`, document structure, text segmentation, and `wrapTag` configuration used when the highlight was created. If a framework re-renders the content or the document changes, persisted positions can no longer be guaranteed. Use the [`Serialize.Restore` hook](./docs/ADVANCE.md#serializerestore) to implement a restoration strategy for changing content.
+
+### Dynamic content and tables
+
+Dynamic DOM is supported after it becomes stable. For asynchronously loaded or frequently re-rendered content, initialize and restore highlights after rendering completes. The library does not support one continuous highlight across table cells, because a wrapper cannot safely span multiple `td` or `th` elements. Use the [`Render.SelectedNodes` hook](./docs/ADVANCE.md#renderselectednodes) to split those selections into supported fragments.
+
 For more details, please read [this article (in Chinese)](https://www.alienzhou.com/2019/04/21/web-note-highlight-in-js/).
 
 ## APIs
@@ -366,6 +374,10 @@ Hooks let you control the highlighting flow powerfully. You can almost customize
 - Opera 15+
 
 _**Mobile supports:**_ automatically detect whether mobile devices and use touch events when on mobile devices.
+
+### Runtime environment
+
+web-highlighter requires browser DOM APIs, including `document`, `Range`, and `Selection`. It supports browsers and WebViews that provide these APIs. Native mini-program renderers and non-DOM native application views are not supported.
 
 ## Advance
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -147,6 +147,14 @@ web-highlighter 会通过 [`Selection API`](https://caniuse.com/#search=selectio
 
 想要了解更多实现细节，可以阅读[这篇文章](https://www.alienzhou.com/2019/04/21/web-note-highlight-in-js/)。
 
+### 持久化约束
+
+持久化的高亮记录的是相对 `$root` 的 DOM 路径和文本偏移，而不是屏幕坐标。请在内容完全渲染后再恢复高亮，并保持创建高亮时使用的 `$root`、文档结构、文本切分方式和 `wrapTag` 配置一致。如果框架重新渲染内容，或文档结构发生变化，持久化位置便无法保证仍然正确。内容会变化时，可以通过 [`Serialize.Restore` 钩子](./docs/ADVANCE.zh_CN.md#serializerestore) 实现自己的恢复策略。
+
+### 动态内容与表格
+
+动态 DOM 在内容稳定后可以正常使用。对于异步加载或频繁重新渲染的内容，请在渲染完成后再初始化和恢复高亮。库不支持跨 table cell 的单一连续高亮，因为一个包裹元素不能安全地跨越多个 `td` 或 `th`。可以使用 [`Render.SelectedNodes` 钩子](./docs/ADVANCE.zh_CN.md#renderselectednodes) 将选区拆分为受支持的片段。
+
 ##  6. <a name='-1'></a>详细使用文档
 
 ###  6.1. <a name='-1'></a>配置项
@@ -362,6 +370,10 @@ highlighter.on(Highlighter.event.CREATE, function (data, inst, e) {
 - Opera 15+
 
 _**移动端支持：**_ 如果检测为移动端，则会自动使用相应的事件监听来替代 PC 端事件。
+
+### 运行环境
+
+web-highlighter 依赖浏览器 DOM API，包括 `document`、`Range` 和 `Selection`。它支持提供这些 API 的浏览器和 WebView；原生小程序渲染层及非 DOM 的原生应用视图不受支持。
 
 ##  8. <a name='-1'></a>更多使用方式
 


### PR DESCRIPTION
## Summary
- document persisted highlight restoration constraints
- clarify dynamic DOM and table-cell limitations
- document required browser DOM APIs and unsupported native renderers

## Validation
- `npm run build-example`