### PR TITLE
fix: ignore ranges without text nodes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,7 @@ export default class Highlighter extends EventEmitter<EventHandlerMap> {
 
         const hRange = new HighlightRange(start, end, text, id);
 
-        if (!hRange) {
+        if (!hRange.isValid()) {
             eventEmitter.emit(INTERNAL_ERROR_EVENT, {
                 type: ERROR.RANGE_INVALID,
             });

--- a/src/model/range/index.ts
+++ b/src/model/range/index.ts
@@ -40,6 +40,8 @@ class HighlightRange {
         this.id = id;
     }
 
+    isValid = (): boolean => Boolean(this.start.$node && this.end.$node);
+
     static fromSelection(idHook: Hook<string>) {
         const range = getDomRange();
 

--- a/test/dist.spec.ts
+++ b/test/dist.spec.ts
@@ -41,6 +41,38 @@ describe('Distribution bundle', function () {
         window.close();
     });
 
+    it('ignores image-only ranges', () => {
+        const bundle = readFileSync(resolve(__dirname, '..', 'dist', 'web-highlighter.min.js'), 'utf-8');
+        const dom = new JSDOM('<main><img></main>', {
+            runScripts: 'dangerously',
+        });
+        const { window } = dom;
+
+        window.eval(bundle);
+
+        const Highlighter = (window as typeof window & { Highlighter: new (options?: any) => any }).Highlighter;
+        const image = window.document.querySelector('img');
+
+        if (!Highlighter || !image) {
+            throw new Error('Expected UMD global and test image');
+        }
+
+        const highlighter = new Highlighter();
+        const range = window.document.createRange();
+
+        range.selectNodeContents(image);
+
+        let source;
+
+        expect(() => {
+            source = highlighter.fromRange(range);
+        }).not.to.throw();
+        expect(source).to.be.null;
+        expect(window.document.querySelector('[data-highlight-id]')).to.be.null;
+
+        window.close();
+    });
+
     it('exposes the UMD global and supports the highlight lifecycle', () => {
         const bundle = readFileSync(resolve(__dirname, '..', 'dist', 'web-highlighter.min.js'), 'utf-8');
         const dom = new JSDOM('<main><p>Highlight this text.</p></main>', {

--- a/test/range.spec.ts
+++ b/test/range.spec.ts
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+import jsdomGlobal from 'jsdom-global';
+import Highlighter from '../src/index';
+import { DATASET_IDENTIFIER, getDefaultOptions } from '../src/util/const';
+
+describe('Highlighter ranges', () => {
+    let cleanup: () => void;
+    let highlighter: Highlighter;
+    let wrapSelector: string;
+
+    beforeEach(() => {
+        cleanup = jsdomGlobal();
+        highlighter = new Highlighter();
+        wrapSelector = `${getDefaultOptions().wrapTag}[data-${DATASET_IDENTIFIER}]`;
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('should ignore ranges that contain no text node', () => {
+        document.body.innerHTML = '<main><img><p></p></main>';
+
+        for (const $target of document.querySelectorAll('img, p')) {
+            const range = document.createRange();
+
+            range.selectNodeContents($target);
+
+            let source;
+
+            expect(() => {
+                source = highlighter.fromRange(range);
+            }).not.to.throw();
+            expect(source).to.be.null;
+        }
+
+        expect(document.querySelector(wrapSelector)).to.be.null;
+    });
+
+    it('should highlight text in a range containing an image', () => {
+        document.body.innerHTML = '<p>before<img>after</p>';
+
+        const $p = document.querySelector('p');
+
+        if (!$p || !$p.firstChild) {
+            throw new Error('Expected paragraph with text content');
+        }
+
+        const range = document.createRange();
+
+        range.setStart($p.firstChild, 0);
+        range.setEnd($p, 2);
+
+        const source = highlighter.fromRange(range);
+
+        expect(source.text).to.equal('before');
+        expect($p.querySelector(wrapSelector).textContent).to.equal('before');
+    });
+});


### PR DESCRIPTION
## Summary
- safely ignore image-only and empty-element ranges instead of reading `parentNode` from an undefined boundary node
- keep mixed text/image ranges working
- cover source behavior and the built UMD bundle

Fixes #125
Fixes #110

## Validation
- `npm run lint`
- `npm test`
- `npm audit` (0 vulnerabilities)