### PR TITLE
docs: fix fromStore example arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ import Highlighter from 'web-highlighter';
 const highlighter = new Highlighter();
 
 // 2. retrieve data from backend, then highlight it on the page
-getRemoteData().then(s => highlighter.fromStore(s.startMeta, s.endMeta, s.id, s.text));
+getRemoteData().then(s => highlighter.fromStore(s.startMeta, s.endMeta, s.text, s.id));
 
 // 3. listen for highlight creating, then save to backend
 highlighter.on(Highlighter.event.CREATE, ({sources}) => save(sources));

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -74,7 +74,7 @@ import Highlighter from 'web-highlighter';
 const highlighter = new Highlighter();
 
 // 2. 从后端获取高亮信息，还原至网页
-getRemoteData().then(s => highlighter.fromStore(s.startMeta, s.endMeta, s.id, s.text));
+getRemoteData().then(s => highlighter.fromStore(s.startMeta, s.endMeta, s.text, s.id));
 
 // 3. 监听高亮笔记创建事件，并将信息存至后端
 highlighter.on(Highlighter.event.CREATE, ({sources}) => save(sources));


### PR DESCRIPTION
## Summary
- correct the `fromStore` argument order in the English and Chinese persistence examples
- use the documented and implemented signature: `fromStore(start, end, text, id)`

## Validation
- `npm run build-example`
- `npm test`