### PR TITLE
fix: reject ranges outside $root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
     getExtraHighlightId,
     getHighlightsByRoot,
     getHighlightId,
+    isInsideRoot,
     addEventListener,
     removeEventListener,
 } from '@src/util/dom';
@@ -205,6 +206,17 @@ export default class Highlighter extends EventEmitter<EventHandlerMap> {
     });
 
     private readonly _highlightFromHRange = (range: HighlightRange): HighlightSource => {
+        if (
+            !isInsideRoot(range.start.$node, this.options.$root) ||
+            !isInsideRoot(range.end.$node, this.options.$root)
+        ) {
+            eventEmitter.emit(INTERNAL_ERROR_EVENT, {
+                type: ERROR.RANGE_OUT_OF_ROOT,
+            });
+
+            return null;
+        }
+
         const source: HighlightSource = range.serialize(this.options.$root, this.hooks);
         const $wraps = this.painter.highlightRange(range);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,6 +31,7 @@ export enum ERROR {
     DOM_SELECTION_EMPTY = '[DOM] The selection contains no dom node, may be you except them.',
     RANGE_INVALID = "[RANGE] Got invalid dom range, can't convert to a valid highlight range.",
     RANGE_NODE_INVALID = "[RANGE] Start or end node isn't a text node, it may occur an error.",
+    RANGE_OUT_OF_ROOT = '[RANGE] Start or end node is outside the root node.',
     DB_ID_DUPLICATE_ERROR = '[STORE] Unique id conflict.',
     CACHE_SET_ERROR = "[CACHE] Cache.data can't be set manually, please use .save().",
     SOURCE_TYPE_ERROR = "[SOURCE] Object isn't a highlight source instance.",

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -41,6 +41,21 @@ const findAncestorWrapperInRoot = ($node: HTMLElement, $root: RootElement): HTML
 };
 
 /**
+ * whether a node is inside the root node (the root node itself included)
+ */
+export const isInsideRoot = ($node: Node, $root: RootElement): boolean => {
+    while ($node) {
+        if ($node === $root) {
+            return true;
+        }
+
+        $node = $node.parentNode;
+    }
+
+    return false;
+};
+
+/**
  * get highlight id by a node
  */
 export const getHighlightId = ($node: HTMLElement, $root: RootElement): string => {

--- a/test/option.spec.ts
+++ b/test/option.spec.ts
@@ -51,6 +51,43 @@ describe('Highlighter Options', function () {
 
             expect(highlighter.getDoms()).lengthOf(0);
         });
+
+        it('should not modify the dom outside $root', () => {
+            const $root = document.querySelectorAll('p')[0];
+            const highlighter = new Highlighter({ $root });
+
+            highlighter.removeAll();
+
+            const $p = document.querySelectorAll('p')[1];
+            const html = $p.innerHTML;
+            const range = document.createRange();
+
+            range.setStart($p.childNodes[0], 0);
+            range.setEnd($p.childNodes[0], 17);
+
+            expect(highlighter.fromRange(range)).to.be.null;
+            expect($p.innerHTML).to.equal(html);
+        });
+
+        it('should not highlight a range partially outside $root', () => {
+            const $root = document.querySelectorAll('p')[0];
+            const highlighter = new Highlighter({ $root });
+
+            highlighter.removeAll();
+
+            const $p = document.querySelectorAll('p')[1];
+            const rootHtml = $root.innerHTML;
+            const outsideHtml = $p.innerHTML;
+            const range = document.createRange();
+
+            range.setStart($root.childNodes[0], 0);
+            range.setEnd($p.childNodes[0], 17);
+
+            expect(highlighter.fromRange(range)).to.be.null;
+            expect($root.innerHTML).to.equal(rootHtml);
+            expect($p.innerHTML).to.equal(outsideHtml);
+            expect(highlighter.getDoms()).lengthOf(0);
+        });
     });
 
     describe('#exceptSelectors', () => {


### PR DESCRIPTION
Fixes #101.

### Problem

`fromRange()` never checked whether the range boundaries belong to the configured `$root`. A range located outside the root was still serialized and painted, so the dom outside the root got rewritten while `getDoms()` — which only queries inside `$root` — kept reporting no highlight. From a user's point of view the page was silently mutated by a highlight the library claimed not to have.

### Fix

Validate both boundaries against `$root` at the beginning of `_highlightFromHRange()`. When either endpoint is outside, nothing is serialized, no dom is touched, no source is cached, and a new `ERROR.RANGE_OUT_OF_ROOT` is emitted instead.

### Tests

Two regression tests in `test/option.spec.ts`:

- a fully-outside range returns `null` and leaves the outside dom untouched;
- a partially-outside range (start inside, end outside) returns `null` and leaves both the root and the outside dom untouched.

`npm test` → 126 passing.