### PR TITLE
fix: convert element range boundaries to text boundaries

### DIFF
--- a/src/model/range/dom.ts
+++ b/src/model/range/dom.ts
@@ -75,20 +75,88 @@ export const getDomMeta = ($node: HTMLElement | Text, offset: number, $root: Doc
     };
 };
 
-export const formatDomNode = (n: DomNode): DomNode => {
-    if (
-        // Text
-        n.$node.nodeType === 3 ||
-        // CDATASection
-        n.$node.nodeType === 4 ||
-        // Comment
-        n.$node.nodeType === 8
-    ) {
+const isTextLikeNode = ($node: Node): boolean =>
+    // Text / CDATASection / Comment
+    $node.nodeType === 3 || $node.nodeType === 4 || $node.nodeType === 8;
+
+/**
+ * find the first (or the last) text node inside a node, the node itself included
+ */
+const findTextNode = ($node: Node, fromStart: boolean): Node => {
+    if (!$node) {
+        return null;
+    }
+
+    if (isTextLikeNode($node)) {
+        return $node;
+    }
+
+    const children = $node.childNodes;
+
+    for (let i = 0; i < children.length; i++) {
+        const $child = children[fromStart ? i : children.length - 1 - i];
+        const $text = findTextNode($child, fromStart);
+
+        if ($text) {
+            return $text;
+        }
+    }
+
+    return null;
+};
+
+/**
+ * find the closest text node after (or before) a boundary of an element node
+ */
+const findAdjacentTextNode = ($node: Node, offset: number, fromStart: boolean): Node => {
+    const children = $node.childNodes;
+    const step = fromStart ? 1 : -1;
+
+    for (let i = fromStart ? offset : offset - 1; i >= 0 && i < children.length; i += step) {
+        const $text = findTextNode(children[i], fromStart);
+
+        if ($text) {
+            return $text;
+        }
+    }
+
+    // no text node inside the element, keep searching in its siblings and ancestors
+    let $cur = $node;
+
+    while ($cur) {
+        const $sibling = fromStart ? $cur.nextSibling : $cur.previousSibling;
+
+        if (!$sibling) {
+            $cur = $cur.parentNode;
+            continue;
+        }
+
+        const $text = findTextNode($sibling, fromStart);
+
+        if ($text) {
+            return $text;
+        }
+
+        $cur = $sibling;
+    }
+
+    return null;
+};
+
+/**
+ * an element boundary (e.g. the end of a range is <p>|<b>text</b></p>) can't be serialized,
+ * so convert it to the equivalent boundary of its closest text node
+ */
+export const formatDomNode = (n: DomNode, isStart: boolean): DomNode => {
+    if (isTextLikeNode(n.$node)) {
         return n;
     }
 
-    return {
-        $node: n.$node.childNodes[n.offset],
-        offset: 0,
-    };
+    const $text = findAdjacentTextNode(n.$node, n.offset, isStart);
+
+    if (!$text) {
+        return { $node: null, offset: 0 };
+    }
+
+    return { $node: $text, offset: isStart ? 0 : $text.textContent.length };
 };

--- a/src/model/range/index.ts
+++ b/src/model/range/index.ts
@@ -33,14 +33,23 @@ class HighlightRange {
             });
         }
 
-        this.start = formatDomNode(start);
-        this.end = formatDomNode(end);
+        this.start = formatDomNode(start, true);
+        this.end = formatDomNode(end, false);
         this.text = text;
         this.frozen = frozen;
         this.id = id;
     }
 
-    isValid = (): boolean => Boolean(this.start.$node && this.end.$node);
+    isValid = (): boolean => {
+        if (!this.start.$node || !this.end.$node) {
+            return false;
+        }
+
+        // the boundaries may be reversed after being converted to text nodes
+        const position = this.start.$node.compareDocumentPosition(this.end.$node);
+
+        return this.start.$node === this.end.$node || !!(position & this.start.$node.DOCUMENT_POSITION_FOLLOWING);
+    };
 
     static fromSelection(idHook: Hook<string>) {
         const range = getDomRange();

--- a/test/integrate.spec.ts
+++ b/test/integrate.spec.ts
@@ -16,30 +16,110 @@ describe('Integration Usage', function () {
 
     it('should work correctly when root contains no dom', () => {
         const html = readFileSync(resolve(__dirname, 'fixtures', 'index.html'), 'utf-8');
+
         document.body.innerHTML = html;
 
         let highlighter = new Highlighter({
-            $root: document.querySelector('p')
+            $root: document.querySelector('p'),
         });
 
         let s: HighlightSource;
+
         (highlighter as any).on(Highlighter.event.CREATE, data => {
             s = data.sources[0];
         });
 
         const range = document.createRange();
         const $p = document.querySelectorAll('p')[0];
+
         range.setStart($p.childNodes[0], 0);
         range.setEnd($p.childNodes[0], 17);
         highlighter.fromRange(range);
+
         const htmlHighlighted = document.body.innerHTML;
 
         document.body.innerHTML = html;
         highlighter = new Highlighter({
-            $root: document.querySelector('p')
+            $root: document.querySelector('p'),
         });
         highlighter.fromStore(s.startMeta, s.endMeta, s.text, s.id);
         expect(document.body.innerHTML).to.be.equal(htmlHighlighted);
+    });
+
+    it('should restore the same text when the range ends at an element boundary', () => {
+        const html = '<main><p>123</p><p><b>345</b></p></main>';
+
+        document.body.innerHTML = html;
+
+        let highlighter = new Highlighter();
+        let s: HighlightSource;
+
+        (highlighter as any).on(Highlighter.event.CREATE, data => {
+            s = data.sources[0];
+        });
+
+        const range = document.createRange();
+        const $paragraphs = document.querySelectorAll('p');
+
+        range.setStart($paragraphs[0].childNodes[0], 0);
+        range.setEnd($paragraphs[1], 0);
+        highlighter.fromRange(range);
+
+        const highlightedText = highlighter
+            .getDoms()
+            .map($n => $n.textContent)
+            .join('');
+
+        expect(highlightedText).to.be.equal('123');
+
+        document.body.innerHTML = html;
+        highlighter = new Highlighter();
+        highlighter.fromStore(s.startMeta, s.endMeta, s.text, s.id);
+
+        expect(
+            highlighter
+                .getDoms()
+                .map($n => $n.textContent)
+                .join(''),
+        ).to.be.equal(highlightedText);
+    });
+
+    it('should restore the same text when the range starts at an element boundary', () => {
+        const html = '<main><p>123</p><p><b>345</b></p></main>';
+
+        document.body.innerHTML = html;
+
+        let highlighter = new Highlighter();
+        let s: HighlightSource;
+
+        (highlighter as any).on(Highlighter.event.CREATE, data => {
+            s = data.sources[0];
+        });
+
+        const range = document.createRange();
+        const $paragraphs = document.querySelectorAll('p');
+
+        range.setStart($paragraphs[1], 0);
+        range.setEnd($paragraphs[1].querySelector('b').childNodes[0], 3);
+        highlighter.fromRange(range);
+
+        const highlightedText = highlighter
+            .getDoms()
+            .map($n => $n.textContent)
+            .join('');
+
+        expect(highlightedText).to.be.equal('345');
+
+        document.body.innerHTML = html;
+        highlighter = new Highlighter();
+        highlighter.fromStore(s.startMeta, s.endMeta, s.text, s.id);
+
+        expect(
+            highlighter
+                .getDoms()
+                .map($n => $n.textContent)
+                .join(''),
+        ).to.be.equal(highlightedText);
     });
 
     afterEach(() => {

--- a/test/range.spec.ts
+++ b/test/range.spec.ts
@@ -37,6 +37,19 @@ describe('Highlighter ranges', () => {
         expect(document.querySelector(wrapSelector)).to.be.null;
     });
 
+    it('should ignore ranges whose element boundaries contain no text node', () => {
+        document.body.innerHTML = '<main><p>before</p><p><img></p><p>after</p></main>';
+
+        const $p = document.querySelectorAll('p')[1];
+        const range = document.createRange();
+
+        range.selectNodeContents($p);
+
+        expect(highlighter.fromRange(range)).to.be.null;
+        expect(document.querySelector(wrapSelector)).to.be.null;
+        expect(document.body.textContent).to.equal('beforeafter');
+    });
+
     it('should highlight text in a range containing an image', () => {
         document.body.innerHTML = '<p>before<img>after</p>';
 


### PR DESCRIPTION
Fixes #99.

### Problem

A `Range` boundary may point at an element node instead of a text node, e.g. `range.setEnd($p, 0)`. `formatDomNode()` mapped such a boundary to `childNodes[offset]`, which is frequently an element as well, while `getTextPreOffset()` (used during serialization) only handles text nodes.

With `<p>123</p><p><b>345</b></p>` and an end boundary of `($secondP, 0)`, the serialized `endMeta` ended up pointing at the end of the nested `<b>` text. Painting was correct, but `fromStore()` restored a highlight of `123345` instead of `123`. A start boundary at an element produced the mirror problem — the restored highlight was empty.

### Fix

Element boundaries are now resolved to the closest text node in the direction of the range:

- start → the following text node at offset `0`;
- end → the preceding text node at its full length.

When the element itself has no text child, the search continues through siblings and ancestors. Ranges that resolve to no text node, or whose boundaries end up reversed after conversion, are reported as invalid (`RANGE_INVALID`) rather than painted.

### Tests

- `test/integrate.spec.ts`: two `fromRange → serialize → fromStore` round-trips whose ranges end / start at an element boundary; both assert the restored text equals the painted text.
- `test/range.spec.ts`: an element boundary with no text node inside is ignored and leaves the dom untouched.

`npm test` → 126 passing (unit) + 3 passing (dist).