### PR TITLE
fix: keep the pointer cursor with a customized className

### DIFF
--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -32,9 +32,11 @@ export const getDefaultOptions = () => ({
 });
 
 export const getStylesheet = () => `
+    [data-${DATASET_IDENTIFIER}] {
+        cursor: pointer;
+    }
     .${getDefaultOptions().style.className} {
         background: #ff9;
-        cursor: pointer;
     }
     .${getDefaultOptions().style.className}.active {
         background: #ffb;

--- a/test/option.spec.ts
+++ b/test/option.spec.ts
@@ -328,6 +328,24 @@ describe('Highlighter Options', function () {
             ).to.be.true;
             expect(highlighter.getDoms().some(n => n.classList.contains(defaultClassName))).to.be.false;
         });
+
+        it('should keep the default interaction style with a customized className', () => {
+            const highlighter = new Highlighter({
+                style: { className: 'test-class-config' },
+            });
+
+            highlighter.removeAll();
+
+            const $p = document.querySelectorAll('p')[0];
+            const range = document.createRange();
+
+            range.setStart($p.childNodes[0], 0);
+            range.setEnd($p.childNodes[0], 17);
+            highlighter.fromRange(range);
+
+            expect(highlighter.getDoms()).lengthOf.gt(0);
+            expect(highlighter.getDoms().every(n => getComputedStyle(n).cursor === 'pointer')).to.be.true;
+        });
     });
 
     afterEach(() => {


### PR DESCRIPTION
Fixes #115.

### Problem

The injected default stylesheet declared `cursor: pointer` on `.highlight-mengshou-wrap`. Configuring `style.className` replaces that class on the wrapper, so a custom-styled highlight lost the pointer cursor — even though it is still hoverable and clickable and still emits `HOVER` / `CLICK` events.

### Fix

Move the interaction rule onto `[data-highlight-id]`, the attribute every wrapper carries regardless of the configured `className`. The background colors stay bound to the default className, so users who override the className keep full control over the visual style while the base interaction affordance is preserved.

### Tests

`test/option.spec.ts`: with a customized `style.className`, every wrapper still computes `cursor: pointer`. Verified the test fails without the stylesheet change.

`npm test` → 127 passing (unit) + 3 passing (dist).