### PR TITLE
feat: expose source data for each highlight wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,10 @@ Get all the wrap nodes in a highlighted area. A highlighted area may contain man
 If the `id` is not passed, it will return all the areas' wrap nodes.
 
 
+#### `highlighter.getSourceByDom(node)`
+
+Get the `HighlightSource` for one wrap node. It accepts the wrapper itself or a descendant node, and returns `null` outside a highlight. Unlike the original source emitted by the `CREATE` event, this source describes only that individual wrapped segment, so its `startMeta` and `endMeta` can be persisted separately after a cross-node or cross-paragraph selection.
+
 #### `highlighter.getIdByDom(node)`
 
 If you have a DOM node, it can return the unique highlight id for you. When passing a non-wrapper element, it will find the nearest ancestor wrapper node.

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -289,7 +289,11 @@ if (!selection.isCollapsed) {
 
 如果 `id` 参数留空，它会返回根节点下的所有高亮区域中的包裹节点。
 
-####  6.3.11. <a name='highlighter.getIdByDomnode'></a>`highlighter.getIdByDom(node)`
+####  6.3.11. <a name='highlighter.getSourceByDomnode'></a>`highlighter.getSourceByDom(node)`
+
+获取单个高亮包裹节点对应的 `HighlightSource`。可以传入包裹节点本身或它的后代节点；不在高亮区域内时返回 `null`。与 `CREATE` 事件中产生的原始 source 不同，该 source 只描述当前包裹片段，因此跨节点或跨段落选区拆分后的每个片段都可以分别获得并持久化自己的 `startMeta`、`endMeta`。
+
+####  6.3.12. <a name='highlighter.getIdByDomnode'></a>`highlighter.getIdByDom(node)`
 
 传入一个 DOM 节点，返回该节点对应的高亮区域的唯一 ID。支持传入非包裹元素。如果是非包裹，则会自动找到最近的祖先包裹元素。
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import type { DomNode, DomMeta, HookMap, HighlighterOptions } from '@src/types';
 import EventEmitter from '@src/util/event.emitter';
 import HighlightRange from '@src/model/range';
+import { getDomMeta } from '@src/model/range/dom';
 import HighlightSource from '@src/model/source';
 import uuid from '@src/util/uuid';
 import Hook from '@src/util/hook';
@@ -17,6 +18,7 @@ import {
     getExtraHighlightId,
     getHighlightsByRoot,
     getHighlightId,
+    getHighlightWrapNode,
     isInsideRoot,
     addEventListener,
     removeEventListener,
@@ -95,6 +97,20 @@ export default class Highlighter extends EventEmitter<EventHandlerMap> {
         id
             ? getHighlightById(this.options.$root, id, this.options.wrapTag)
             : getHighlightsByRoot(this.options.$root, this.options.wrapTag);
+
+    getSourceByDom = ($node: HTMLElement): HighlightSource => {
+        const $wrap = getHighlightWrapNode($node, this.options.$root);
+        const $text = $wrap && ($wrap.firstChild as Text);
+
+        if (!$text || $text.nodeType !== 3) {
+            return null;
+        }
+
+        const start = getDomMeta($text, 0, this.options.$root);
+        const end = getDomMeta($text, $text.length, this.options.$root);
+
+        return new HighlightSource(start, end, $text.textContent, getHighlightId($wrap, this.options.$root));
+    };
 
     dispose = () => {
         const $root = this.options.$root;

--- a/src/util/dom.ts
+++ b/src/util/dom.ts
@@ -55,11 +55,14 @@ export const isInsideRoot = ($node: Node, $root: RootElement): boolean => {
     return false;
 };
 
+export const getHighlightWrapNode = ($node: HTMLElement, $root: RootElement): HTMLElement =>
+    findAncestorWrapperInRoot($node, $root);
+
 /**
  * get highlight id by a node
  */
 export const getHighlightId = ($node: HTMLElement, $root: RootElement): string => {
-    $node = findAncestorWrapperInRoot($node, $root);
+    $node = getHighlightWrapNode($node, $root);
 
     if (!$node) {
         return '';
@@ -72,7 +75,7 @@ export const getHighlightId = ($node: HTMLElement, $root: RootElement): string =
  * get extra highlight id by a node
  */
 export const getExtraHighlightId = ($node: HTMLElement, $root: RootElement): string[] => {
-    $node = findAncestorWrapperInRoot($node, $root);
+    $node = getHighlightWrapNode($node, $root);
 
     if (!$node) {
         return [];

--- a/test/api.spec.ts
+++ b/test/api.spec.ts
@@ -339,6 +339,40 @@ describe('Highlighter API', function () {
         });
     });
 
+    describe('#getSourceByDom', () => {
+        it('should get a source for each wrapper in a cross-paragraph highlight', () => {
+            const $paragraphs = document.querySelectorAll('p');
+            const range = document.createRange();
+
+            range.setStart($paragraphs[0].childNodes[0], 0);
+            range.setEnd($paragraphs[1].childNodes[0], 17);
+            const source = highlighter.fromRange(range);
+            const wrappers = highlighter.getDoms(source.id);
+            const wrapperSources = wrappers.map($node => highlighter.getSourceByDom($node));
+
+            expect(wrapperSources.map(s => s.text).join('')).to.equal(source.text);
+            expect(wrapperSources.every(s => s.id === source.id)).to.be.true;
+            expect(wrapperSources.map(s => s.startMeta.parentIndex)).to.deep.equal([0, 0, 1]);
+            expect(wrapperSources.map(s => s.startMeta.textOffset)).to.deep.equal([0, 150, 0]);
+        });
+
+        it('should get a source from a node inside a wrapper', () => {
+            const $p = document.querySelectorAll('p')[0];
+            const range = document.createRange();
+
+            range.setStart($p.childNodes[0], 0);
+            range.setEnd($p.childNodes[0], 17);
+            const source = highlighter.fromRange(range);
+            const wrapper = highlighter.getDoms(source.id)[0];
+
+            expect(highlighter.getSourceByDom(wrapper.firstChild as HTMLElement).text).to.equal(source.text);
+        });
+
+        it('should return null for a node outside a wrapper', () => {
+            expect(highlighter.getSourceByDom(document.querySelector('img'))).to.be.null;
+        });
+    });
+
     describe('#addClass', () => {
         const className = 'test-class';
 


### PR DESCRIPTION
Fixes #111.

### Problem

A cross-node or cross-paragraph selection emits one combined `HighlightSource`, but is rendered as several wrapper nodes. `getDoms(id)` exposes those nodes, yet applications had no public API for obtaining the `parentIndex` and `textOffset` for an individual wrapper after the range was split.

### Fix

Add `highlighter.getSourceByDom(node)`:

- accepts a highlight wrapper or a descendant node;
- returns a `HighlightSource` for that one wrapped segment;
- returns `null` outside a highlight;
- preserves the wrapper's primary highlight id.

Consumers can now use `highlighter.getDoms(id).map(highlighter.getSourceByDom)` to persist individual segments after a cross-paragraph selection.

### Tests and docs

- Tests cover per-wrapper source metadata in a cross-paragraph selection, descendant lookup, and non-wrapper input.
- Documented in both READMEs.

Verification: `npm run lint`, `npm test` → 131 unit + 3 dist passing.