### PR TITLE
fix: stop truncating the native selection when highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ It will stop the auto-highlighting.
 
 When you don't want the highlighter anymore, remember to call it first. It will remove some listeners and do some cleanup.
 
-#### `highlighter.fromRange(range)`
+#### `highlighter.fromRange(range, [options])`
 
 You can pass a [`Range`](https://developer.mozilla.org/en-US/docs/Web/API/Range) object to it and then it will be highlighted. You can use `window.getSelection().getRangeAt(0)` to get a range object or use `document.createRange()` to create a new range.
 
@@ -254,6 +254,21 @@ if (!selection.isCollapsed) {
     highlighter.fromRange(selection.getRangeAt(0));
 }
 ```
+
+Highlighting splits and replaces text nodes. A native selection is live, so the browser recomputes its boundaries while that happens and may truncate it when the selection spans several text nodes. `options.selection` decides what happens to the native selection:
+
+| value | behaviour |
+|---|---|
+| `keep` | the default, the native selection is left to the caller |
+| `clear` | the native selection is dropped before the DOM is modified |
+| `restore` | the created wrappers are selected after highlighting |
+
+```JavaScript
+// pass the current selection and keep the same text selected afterwards
+highlighter.fromRange(selection.getRangeAt(0), { selection: 'restore' });
+```
+
+`highlighter.run()` always clears the native selection before modifying the DOM.
 
 #### `highlighter.fromStore(start, end, text, id)`
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -241,7 +241,7 @@ var highlighter = new Highlighter({
 
 当你不再需要使用高亮功能时，需要先使用该方法来移除一些事件监听，回收一些资源。
 
-####  6.3.4. <a name='highlighter.fromRangerange'></a>`highlighter.fromRange(range)`
+####  6.3.4. <a name='highlighter.fromRangerange'></a>`highlighter.fromRange(range, [options])`
 
 该方法支持你传一个 [`Range`](https://developer.mozilla.org/en-US/docs/Web/API/Range)，并基于该对象进行高亮笔记操作。你可以通过 `window.getSelection().getRangeAt(0)` 方法来获取一个 range 对象，或者使用 `document.createRange()` 方法来创建一个新的 range 对象。
 
@@ -253,6 +253,21 @@ if (!selection.isCollapsed) {
     highlighter.fromRange(selection.getRangeAt(0));
 }
 ```
+
+高亮过程会拆分并替换文本节点。而原生 selection 是「活」的，浏览器会在此过程中重算它的端点；当选区跨越多个文本节点时，重算结果可能被截断。`options.selection` 用于指定原生 selection 的处理方式：
+
+| 取值 | 行为 |
+|---|---|
+| `keep` | 默认值，不改动原生 selection，交由调用方自行处理 |
+| `clear` | 在修改 DOM 之前清除原生 selection |
+| `restore` | 高亮完成后重新选中生成的包裹元素 |
+
+```JavaScript
+// 传入当前选区，并在高亮后保持相同文本处于选中状态
+highlighter.fromRange(selection.getRangeAt(0), { selection: 'restore' });
+```
+
+`highlighter.run()` 自动模式下始终会在修改 DOM 之前清除原生 selection。
 
 ####  6.3.5. <a name='highlighter.fromStorestartendtextid'></a>`highlighter.fromStore(start, end, text, id)`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { DomNode, DomMeta, HookMap, HighlighterOptions } from '@src/types';
+import type { DomNode, DomMeta, HookMap, HighlighterOptions, FromRangeOptions, SelectionMode } from '@src/types';
 import EventEmitter from '@src/util/event.emitter';
 import HighlightRange from '@src/model/range';
 import { getDomMeta } from '@src/model/range/dom';
@@ -137,7 +137,7 @@ export default class Highlighter extends EventEmitter<EventHandlerMap> {
         );
     };
 
-    fromRange = (range: Range): HighlightSource => {
+    fromRange = (range: Range, options?: FromRangeOptions): HighlightSource => {
         const start: DomNode = {
             $node: range.startContainer,
             offset: range.startOffset,
@@ -162,7 +162,7 @@ export default class Highlighter extends EventEmitter<EventHandlerMap> {
             return null;
         }
 
-        return this._highlightFromHRange(hRange);
+        return this._highlightFromHRange(hRange, options?.selection ?? 'keep');
     };
 
     fromStore = (start: DomMeta, end: DomMeta, text: string, id: string, extra?: unknown): HighlightSource => {
@@ -221,7 +221,10 @@ export default class Highlighter extends EventEmitter<EventHandlerMap> {
         },
     });
 
-    private readonly _highlightFromHRange = (range: HighlightRange): HighlightSource => {
+    private readonly _highlightFromHRange = (
+        range: HighlightRange,
+        selectionMode: SelectionMode = 'keep',
+    ): HighlightSource => {
         if (
             !isInsideRoot(range.start.$node, this.options.$root) ||
             !isInsideRoot(range.end.$node, this.options.$root)
@@ -234,6 +237,13 @@ export default class Highlighter extends EventEmitter<EventHandlerMap> {
         }
 
         const source: HighlightSource = range.serialize(this.options.$root, this.hooks);
+
+        // the native selection is live: splitting text nodes while it still
+        // covers them makes the browser recompute (and truncate) its boundaries
+        if (selectionMode !== 'keep') {
+            HighlightRange.removeDomRange();
+        }
+
         const $wraps = this.painter.highlightRange(range);
 
         if ($wraps.length === 0) {
@@ -242,6 +252,10 @@ export default class Highlighter extends EventEmitter<EventHandlerMap> {
             });
 
             return null;
+        }
+
+        if (selectionMode === 'restore') {
+            HighlightRange.restoreDomRange($wraps);
         }
 
         this.cache.save(source);
@@ -261,8 +275,7 @@ export default class Highlighter extends EventEmitter<EventHandlerMap> {
         const range = HighlightRange.fromSelection(this.hooks.Render.UUID);
 
         if (range) {
-            this._highlightFromHRange(range);
-            HighlightRange.removeDomRange();
+            this._highlightFromHRange(range, 'clear');
         }
     };
 

--- a/src/model/range/index.ts
+++ b/src/model/range/index.ts
@@ -8,13 +8,15 @@ import type { DomNode, HookMap } from '@src/types';
 import type Hook from '@src/util/hook';
 import HighlightSource from '@src/model/source/index';
 import { ERROR } from '@src/types';
-import { getDomRange, removeSelection } from '@src/model/range/selection';
+import { getDomRange, removeSelection, restoreSelection } from '@src/model/range/selection';
 import uuid from '@src/util/uuid';
 import { getDomMeta, formatDomNode } from '@src/model/range/dom';
 import { eventEmitter, INTERNAL_ERROR_EVENT } from '@src/util/const';
 
 class HighlightRange {
     static removeDomRange = removeSelection;
+
+    static restoreDomRange = restoreSelection;
 
     start: DomNode;
 

--- a/src/model/range/selection.ts
+++ b/src/model/range/selection.ts
@@ -20,3 +20,24 @@ export const getDomRange = (): Range => {
 export const removeSelection = (): void => {
     window.getSelection().removeAllRanges();
 };
+
+/**
+ * select the given wrappers as a whole
+ * the highlighted text may be split into several wrappers,
+ * so only the range they cover is restored
+ */
+export const restoreSelection = ($nodes: HTMLElement[]): void => {
+    const selection = window.getSelection();
+
+    selection.removeAllRanges();
+
+    if ($nodes.length === 0) {
+        return;
+    }
+
+    const range = document.createRange();
+
+    range.setStartBefore($nodes[0]);
+    range.setEndAfter($nodes[$nodes.length - 1]);
+    selection.addRange(range);
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,18 @@ export interface PainterOptions {
     exceptSelectors: string[];
 }
 
+/**
+ * how the native selection should be handled after a highlight is created
+ *  - keep: leave it to the caller (the default of .fromRange)
+ *  - clear: drop the native selection
+ *  - restore: select the created wrappers
+ */
+export type SelectionMode = 'keep' | 'clear' | 'restore';
+
+export interface FromRangeOptions {
+    selection?: SelectionMode;
+}
+
 export enum SplitType {
     none = 'none',
     head = 'head',

--- a/test/selection.spec.ts
+++ b/test/selection.spec.ts
@@ -1,0 +1,79 @@
+import { expect } from 'chai';
+import jsdomGlobal from 'jsdom-global';
+import Highlighter from '../src/index';
+
+describe('Native selection lifecycle', function () {
+    this.timeout(50000);
+
+    let cleanup: () => void;
+
+    beforeEach(() => {
+        cleanup = jsdomGlobal();
+        document.body.innerHTML = '<p>start <a href="#">link</a> middle <i>italic</i> end</p>';
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    const selectAcrossTextNodes = () => {
+        const $p = document.querySelector('p');
+        const range = document.createRange();
+
+        range.setStart($p.firstChild, 2);
+        range.setEnd($p.lastChild, 3);
+
+        const selection = window.getSelection();
+
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        return { range, text: range.toString() };
+    };
+
+    it('should keep the native selection untouched by default', () => {
+        const { range } = selectAcrossTextNodes();
+        const highlighter = new Highlighter();
+
+        expect(highlighter.fromRange(range)).not.to.be.null;
+        expect(window.getSelection().rangeCount).to.equal(1);
+    });
+
+    it('should drop the native selection when asked to clear it', () => {
+        const { range, text } = selectAcrossTextNodes();
+        const highlighter = new Highlighter();
+
+        const source = highlighter.fromRange(range, { selection: 'clear' });
+
+        expect(source.text).to.equal(text);
+        expect(window.getSelection().isCollapsed).to.be.true;
+    });
+
+    it('should select the created wrappers when asked to restore it', () => {
+        const { range, text } = selectAcrossTextNodes();
+        const highlighter = new Highlighter();
+
+        const source = highlighter.fromRange(range, { selection: 'restore' });
+
+        expect(source.text).to.equal(text);
+        expect(window.getSelection().toString()).to.equal(text);
+    });
+
+    it('should not leave a truncated selection in the automatic mode', () => {
+        const highlighter = new Highlighter();
+
+        highlighter.run();
+
+        const { text } = selectAcrossTextNodes();
+
+        document.body.dispatchEvent(new MouseEvent('mouseup', { view: window, bubbles: true, cancelable: true }));
+
+        expect(
+            highlighter
+                .getDoms()
+                .map($n => $n.textContent)
+                .join(''),
+        ).to.equal(text);
+        expect(window.getSelection().isCollapsed).to.be.true;
+    });
+});


### PR DESCRIPTION
Fixes #106.

### Problem

Painting a highlight calls `splitText()` on the original text nodes and replaces them with wrappers. A native `Selection` is **live**, so the browser recomputes its boundaries as those nodes are split and replaced. When the selection spans several text nodes in one paragraph (separated by inline elements such as `<a>` / `<i>`), the recomputed selection loses the final text node — the highlight is painted correctly, but the page keeps a truncated blue selection.

Reproduced in a regression test: selecting `art link middle italic end` left `art link middle italic` selected after `fromRange()`.

The two entry points also disagreed: `run()` cleared the selection *after* painting, while `fromRange()` never touched it.

### Fix

The selection belongs to the caller, so the library releases it *before* mutating the DOM rather than trying to repair a shredded range afterwards.

- `run()` now clears the native selection **before** painting, so the live range is never recomputed mid-split.
- `fromRange()` keeps its current no-side-effect contract by default (`selection: 'keep'`) and gains an explicit `options.selection`:
  - `clear` — drop the selection before the DOM changes (the fix for browser extensions);
  - `restore` — select the created wrappers afterwards.

`restore` only restores the range the wrappers cover; it does not promise character-exact equivalence across `exceptSelectors`, overlapping highlights or element boundaries. That boundary is documented.

### Tests and docs

- New `test/selection.spec.ts` covers all three modes plus the automatic mode.
- Both READMEs document the option and the live-selection constraint.

Verification: `npm run lint`, `npm test` → 135 unit + 3 dist passing.