### PR TITLE
docs: correct CREATE event payload field name

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,10 +377,12 @@ Different event has different `data`. Attributes below:
 
 |name|description|type|
 |---|---|---|
-|`source`|`HighlightSource` object|Array<HighlightSource>|
+|`sources`|a list of `HighlightSource` objects|Array<HighlightSource>|
 |`type`|the reason for creating|string|
 
-`source` is a `HighlightSource` object. It is an object created by web-highlighter when highlighted area created. For persistence in backend (database), it's necessary to use a data structure which can be serialized (`JSON.stringify()`) to represent a dom node in browsers. `HighlightSource` is the data structure designed for this.
+> The callback receives a single object, so destructure it as `({sources, type}) => ...`. Each item of `sources` is a `HighlightSource`; pass an item (not the wrapper object) to `Highlighter.isHighlightSource()`.
+
+`sources` is a list of `HighlightSource` objects. Such an object is created by web-highlighter when highlighted area created. For persistence in backend (database), it's necessary to use a data structure which can be serialized (`JSON.stringify()`) to represent a dom node in browsers. `HighlightSource` is the data structure designed for this.
 
 `type` explains why a highlighted area is be created. Now `type` has two possible values: `from-input` and `from-store`. `from-input` shows that a highlighted area is created because of user's selection. `from-store` means it from a storage.
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -373,10 +373,12 @@ highlighter.on(Highlighter.event.CREATE, function (data, inst, e) {
 
 |name|description|type|
 |---|---|---|
-|`source`|`HighlightSource` 对象|Array|
+|`sources`|`HighlightSource` 对象数组|Array&lt;HighlightSource&gt;|
 |`type`|高亮区域创建的来源|string|
 
-`source` 是一个 `HighlightSource` 对象。该对象在高亮区域被创建时，会由 web-highlighter 创建并传给回调函数。为了能够在后端（数据库中）进行高亮数据的持久化，需要使用一个可以被序列化（`JSON.stringify()`）的数据结构来表示浏览器中的 DOM 节点。`HighlightSource` 就是 web-highlighter 提供的来用于持久化的数据对象。
+> 回调只接收一个对象参数，因此请按 `({sources, type}) => ...` 解构使用。`sources` 中的每一项都是 `HighlightSource`；调用 `Highlighter.isHighlightSource()` 时需要传入数组中的某一项，而不是整个回调参数对象。
+
+`sources` 是一个 `HighlightSource` 对象数组。这些对象在高亮区域被创建时，会由 web-highlighter 创建并传给回调函数。为了能够在后端（数据库中）进行高亮数据的持久化，需要使用一个可以被序列化（`JSON.stringify()`）的数据结构来表示浏览器中的 DOM 节点。`HighlightSource` 就是 web-highlighter 提供的来用于持久化的数据对象。
 
 `type` 用来告知开发者高亮区域被创建的原因。目前 `type` 包含两种可能的值：`from-input` 和 `from-store`。`from-input` 表明该高亮区域是通过用户操作（用户划词的选区）创建的；`from-store` 则表示该高亮区域是通过持久化的 `HighlightSource` 中的数据还原出来的。
 


### PR DESCRIPTION
## Why

`EventType.CREATE` emits `{sources, type}`, but both READMEs documented the field as `source`. Users following the docs passed the whole payload object into `Highlighter.isHighlightSource()` and got `false` (see #74).

## What

- Rename `source` → `sources` in the `EventType.CREATE` payload tables (EN + zh-CN).
- Add a note that the callback receives a single object and should be destructured as `({sources, type}) => ...`.

Docs only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)